### PR TITLE
Add `of_eltype`, for lazy element type conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,33 @@ julia> b = mappedarray(abs, a)
  0.486558  1.27959   1.59661   1.05867   2.06828
  0.315976  0.188828  0.567672  0.405086  1.06983
 ```
+
+### of_eltype
+
+This package defines a convenience method, `of_eltype`, which
+"lazily-converts" arrays to a specific `eltype`.  (It works simply by
+defining `convert` functions for both `f` and `finv`.)
+
+Using `of_eltype` you can "convert" a series of arrays to a chosen element type:
+
+```julia
+julia> arrays = (rand(2,2), rand(Int,2,2), [0x01 0x03; 0x02 0x04])
+(
+[0.541018 0.223392; 0.341264 0.022014],
+
+[2437062103055434647 4726011606246170825; -4226911569217925847 -8715663020460318733],
+
+UInt8[0x01 0x03; 0x02 0x04])
+
+julia> arraysT = map(A->of_eltype(Float64, A), arrays)
+(
+[0.541018 0.223392; 0.341264 0.022014],
+
+[2.43706e18 4.72601e18; -4.22691e18 -8.71566e18],
+
+[1.0 3.0; 2.0 4.0])
+```
+
+This construct is inferrable (type-stable), so it can be a useful
+means to "coerce" arrays to a common type. This can sometimes solve
+type-stability problems without requiring that one copy the data.

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -2,7 +2,7 @@ module MappedArrays
 
 using Base: @propagate_inbounds
 
-export mappedarray
+export mappedarray, of_eltype
 
 abstract AbstractMappedArray{T,N} <: AbstractArray{T,N}
 
@@ -35,6 +35,14 @@ function mappedarray{T,N}(f_finv::Tuple{Any,Any}, data::AbstractArray{T,N})
     f, finv = f_finv
     MappedArray{typeof(f(one(T))),N,typeof(data),typeof(f),typeof(finv)}(f, finv, data)
 end
+
+"""
+    of_eltype(T, A)
+
+creates a view of `A` that lazily-converts the element type to `T`.
+"""
+of_eltype{S,T}(::Type{T}, data::AbstractArray{S}) = mappedarray((x->convert(T,x), y->convert(S,y)), data)
+of_eltype{T}(::Type{T}, data::AbstractArray{T}) = data
 
 Base.parent(A::AbstractMappedArray) = A.data
 Base.size(A::AbstractMappedArray) = size(A.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,3 +44,12 @@ for i = 1:4
 end
 b[2,1] = 10/255
 @test a[2,1] == 0x0a
+
+a = [0.1 0.3; 0.2 0.4]
+b = @inferred(of_eltype(UFixed8, a))
+@test b[1,1] === UFixed8(0.1)
+b[2,1] = UFixed8(0.5)
+@test a[2,1] == UFixed8(0.5)
+@test !(b === a)
+b = of_eltype(Float64, a)
+@test b === a


### PR DESCRIPTION
The main convenience here is defining the inverse function, so that the array remains read/write.