### PR TITLE
Make mappedarray type-inferable for Strings and friends

### DIFF
--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -62,9 +62,10 @@ parenttype{T,N,A,F,Finv}(::Type{MappedArray{T,N,A,F,Finv}}) = A
 
 function testvalue(data)
     if !isempty(data)
-        return first(data)
-    end
-    zero(eltype(data))
+        first(data)
+    else
+        zero(eltype(data))
+    end::eltype(data)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Base.Test
 a = [1,4,9,16]
 s = view(a', 1:1, [1,2,4])
 
-b = mappedarray(sqrt, a)
+b = @inferred(mappedarray(sqrt, a))
 @test parent(b) === a
 @test eltype(b) == Float64
 @test @inferred(getindex(b, 1)) == 1
@@ -18,7 +18,7 @@ b = mappedarray(sqrt, a')
 b = mappedarray(sqrt, s)
 @test isa(eachindex(b), CartesianRange)
 
-c = mappedarray((sqrt, x->x*x), a)
+c = @inferred(mappedarray((sqrt, x->x*x), a))
 @test parent(c) === a
 @test @inferred(getindex(c, 1)) == 1
 @test c[2] == 2
@@ -28,9 +28,9 @@ c[3] = 2
 @test a[3] == 4
 @test_throws InexactError c[3] = 2.2  # because the backing array is Array{Int}
 @test isa(eachindex(c), AbstractUnitRange)
-b = mappedarray(sqrt, a')
+b = @inferred(mappedarray(sqrt, a'))
 @test isa(eachindex(b), AbstractUnitRange)
-c = mappedarray((sqrt, x->x*x), s)
+c = @inferred(mappedarray((sqrt, x->x*x), s))
 @test isa(eachindex(c), CartesianRange)
 
 sb = similar(b)
@@ -38,7 +38,7 @@ sb = similar(b)
 @test size(sb) == size(b)
 
 a = [0x01 0x03; 0x02 0x04]
-b = mappedarray((y->N0f8(y,0),x->x.i), a)
+b = @inferred(mappedarray((y->N0f8(y,0),x->x.i), a))
 for i = 1:4
     @test b[i] == N0f8(i/255)
 end
@@ -67,8 +67,13 @@ for i = -2:2
 end
 
 # issue #7
-astr = mappedarray(length, ["abc", "onetwothree"])
+astr = @inferred(mappedarray(length, ["abc", "onetwothree"]))
 @test eltype(astr) == Int
 @test astr == [3, 11]
-a = mappedarray(x->x+0.5, Int[])
+a = @inferred(mappedarray(x->x+0.5, Int[]))
 @test eltype(a) == Float64
+
+# typestable string
+astr = @inferred(mappedarray(uppercase, ["abc", "def"]))
+@test eltype(astr) == String
+@test astr == ["ABC","DEF"]


### PR DESCRIPTION
Basically fixes

```julia
julia> @inferred(mappedarray(length, ["abc", "onetwothree"]))
ERROR: return type MappedArrays.ReadonlyMappedArray{Int64,1,Array{String,1},Base.#length} does not match inferred return type MappedArrays.ReadonlyMappedArray{T,N,A<:AbstractArray,F}
 in error(::String) at ./error.jl:21

julia> @inferred(mappedarray(uppercase, ["abc", "def"]))
ERROR: return type MappedArrays.ReadonlyMappedArray{String,1,Array{String,1},Base.#uppercase} does not match inferred return type MappedArrays.ReadonlyMappedArray{T,N,A<:AbstractArray,F}
 in error(::String) at ./error.jl:21
```