### PR TITLE
Support `mappedarray(f, A, B, C...)`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.6
-Compat 0.19.0

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -3,7 +3,6 @@ __precompile__()
 module MappedArrays
 
 using Base: @propagate_inbounds
-using Compat
 
 export AbstractMappedArray, MappedArray, ReadonlyMappedArray, mappedarray, of_eltype
 
@@ -18,14 +17,40 @@ struct MappedArray{T,N,A<:AbstractArray,F,Finv} <: AbstractMappedArray{T,N}
     finv::Finv
     data::A
 end
+struct ReadonlyMultiMappedArray{T,N,AAs<:Tuple{Vararg{AbstractArray}},F} <: AbstractMappedArray{T,N}
+    f::F
+    data::AAs
+
+    function ReadonlyMultiMappedArray{T,N,AAs,F}(f, data) where {T,N,AAs,F}
+        inds = indices(first(data))
+        checkinds(inds, Base.tail(data)...)
+        new(f, data)
+    end
+end
+
+# TODO: remove @inline for 0.7
+@inline function checkinds(inds, A, As...)
+    @noinline throw1(i, j) = throw(DimensionMismatch("arrays do not all have the same indices (got $i and $j)"))
+    iA = indices(A)
+    iA == inds || throw1(inds, iA)
+    checkinds(inds, As...)
+end
+checkinds(inds) = nothing
 
 """
-     mappedarray(f, A)
+    M = mappedarray(f, A)
+    M = mappedarray(f, A, B, C...)
 
-creates a view of the array `A` that applies `f` to every element of
-`A`. The view is read-only (you can get values but not set them).
+Create a view `M` of the array `A` that applies `f` to every element
+of `A`; `M == map(f, A)`, with the difference that no storage
+is allocated for `M`. The view is read-only (you can get values but
+not set them).
+
+When multiple input arrays are supplied, `M[i] = f(A[i], B[i], C[i]...)`.
 """
 mappedarray(f, data::AbstractArray{T,N}) where {T,N} = ReadonlyMappedArray{typeof(f(testvalue(data))),N,typeof(data),typeof(f)}(f, data)
+
+mappedarray(f, data::AbstractArray...) = ReadonlyMultiMappedArray{typeof(f(map(testvalue, data)...)),ndims(first(data)),typeof(data),typeof(f)}(f, data)
 
 """
     mappedarray((f, finv), A)
@@ -51,14 +76,51 @@ of_eltype(::T, data::AbstractArray{S}) where {S,T} = of_eltype(T, data)
 
 Base.parent(A::AbstractMappedArray) = A.data
 Base.size(A::AbstractMappedArray) = size(A.data)
+Base.size(A::ReadonlyMultiMappedArray) = size(first(A.data))
 Base.indices(A::AbstractMappedArray) = indices(A.data)
+Base.indices(A::ReadonlyMultiMappedArray) = indices(first(A.data))
 parenttype(::Type{ReadonlyMappedArray{T,N,A,F}}) where {T,N,A,F} = A
 parenttype(::Type{MappedArray{T,N,A,F,Finv}}) where {T,N,A,F,Finv} = A
+parenttype(::Type{ReadonlyMultiMappedArray{T,N,A,F}}) where {T,N,A,F} = A
 Base.IndexStyle(::Type{MA}) where {MA<:AbstractMappedArray} = IndexStyle(parenttype(MA))
+Base.@pure Base.IndexStyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} = _indexstyle(map(IndexStyle, parenttype(MA).parameters)...)
+_indexstyle(a, b, c...) = _indexstyle(IndexStyle(a, b), c...)
+_indexstyle(a, b) = IndexStyle(a, b)
 
-@propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int...) = A.f(A.data[i...])
-@propagate_inbounds Base.setindex!(A::MappedArray{T}, val::T, i::Int...) where {T} = A.data[i...] = A.finv(val)
-@inline Base.setindex!(A::MappedArray{T}, val, i::Int...) where {T} = setindex!(A, convert(T, val), i...)
+
+# IndexLinear implementations
+@propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int) =
+    A.f(A.data[i])
+@propagate_inbounds Base.getindex(M::ReadonlyMultiMappedArray, i::Int) =
+    M.f(map(A->A[i], M.data)...)
+@propagate_inbounds function Base.setindex!(A::MappedArray{T},
+                                            val::T,
+                                            i::Int) where {T}
+    A.data[i] = A.finv(val)
+end
+@inline function Base.setindex!(A::MappedArray{T},
+                                val, i::Int) where {T}
+    setindex!(A, convert(T, val), i)
+end
+
+# IndexCartesian implementations
+@propagate_inbounds function Base.getindex(A::AbstractMappedArray{T,N},
+                                           i::Vararg{Int,N}) where {T,N}
+    A.f(A.data[i...])
+end
+@propagate_inbounds function Base.getindex(M::ReadonlyMultiMappedArray{T,N},
+                                           i::Vararg{Int,N}) where {T,N}
+    M.f(map(A->A[i...], M.data)...)
+end
+@propagate_inbounds function Base.setindex!(A::MappedArray{T,N},
+                                            val::T,
+                                            i::Vararg{Int,N}) where {T,N}
+    A.data[i...] = A.finv(val)
+end
+@inline function Base.setindex!(A::MappedArray{T,N},
+                                val, i::Vararg{Int,N}) where {T,N}
+    setindex!(A, convert(T, val), i...)
+end
 
 function testvalue(data)
     if !isempty(data)

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -83,7 +83,10 @@ parenttype(::Type{ReadonlyMappedArray{T,N,A,F}}) where {T,N,A,F} = A
 parenttype(::Type{MappedArray{T,N,A,F,Finv}}) where {T,N,A,F,Finv} = A
 parenttype(::Type{ReadonlyMultiMappedArray{T,N,A,F}}) where {T,N,A,F} = A
 Base.IndexStyle(::Type{MA}) where {MA<:AbstractMappedArray} = IndexStyle(parenttype(MA))
-Base.@pure Base.IndexStyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} = _indexstyle(map(IndexStyle, parenttype(MA).parameters)...)
+@inline Base.IndexStyle(M::ReadonlyMultiMappedArray) = IndexStyle(M.data...)
+Base.IndexStyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} = _indexstyle(MA)
+Base.@pure _indexstyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} =
+    _indexstyle(map(IndexStyle, parenttype(MA).parameters)...)
 _indexstyle(a, b, c...) = _indexstyle(IndexStyle(a, b), c...)
 _indexstyle(a, b) = IndexStyle(a, b)
 

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -91,8 +91,9 @@ _indexstyle(a, b) = IndexStyle(a, b)
 # IndexLinear implementations
 @propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int) =
     A.f(A.data[i])
-@propagate_inbounds Base.getindex(M::ReadonlyMultiMappedArray, i::Int) =
-    M.f(map(A->A[i], M.data)...)
+@propagate_inbounds function Base.getindex(M::ReadonlyMultiMappedArray, i::Int)
+    M.f(_getindex(i, M.data...)...)
+end
 @propagate_inbounds function Base.setindex!(A::MappedArray{T},
                                             val::T,
                                             i::Int) where {T}
@@ -110,7 +111,7 @@ end
 end
 @propagate_inbounds function Base.getindex(M::ReadonlyMultiMappedArray{T,N},
                                            i::Vararg{Int,N}) where {T,N}
-    M.f(map(A->A[i...], M.data)...)
+    M.f(_getindex(CartesianIndex(i), M.data...)...)
 end
 @propagate_inbounds function Base.setindex!(A::MappedArray{T,N},
                                             val::T,
@@ -121,6 +122,9 @@ end
                                 val, i::Vararg{Int,N}) where {T,N}
     setindex!(A, convert(T, val), i...)
 end
+
+@propagate_inbounds _getindex(i, A, As...) = (A[i], _getindex(i, As...)...)
+_getindex(i) = ()
 
 function testvalue(data)
     if !isempty(data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,3 +77,19 @@ a = @inferred(mappedarray(x->x+0.5, Int[]))
 astr = @inferred(mappedarray(uppercase, ["abc", "def"]))
 @test eltype(astr) == String
 @test astr == ["ABC","DEF"]
+
+# multiple arrays
+a = reshape(1:6, 2, 3)
+b = fill(10.0f0, 2, 3)
+M = @inferred(mappedarray(+, a, b))
+@test @inferred(eltype(M)) == Float32
+@test @inferred(IndexStyle(M)) == IndexLinear()
+@test M == a + b
+@test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
+
+c = view(reshape(1:9, 3, 3), 1:2, :)
+M = @inferred(mappedarray(+, c, b))
+@test @inferred(eltype(M)) == Float32
+@test @inferred(IndexStyle(M)) == IndexCartesian()
+@test M == c + b
+@test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,16 +80,23 @@ astr = @inferred(mappedarray(uppercase, ["abc", "def"]))
 
 # multiple arrays
 a = reshape(1:6, 2, 3)
+@test @inferred(indices(a)) == (Base.OneTo(2), Base.OneTo(3)) # prevents error on 0.7
 b = fill(10.0f0, 2, 3)
 M = @inferred(mappedarray(+, a, b))
 @test @inferred(eltype(M)) == Float32
 @test @inferred(IndexStyle(M)) == IndexLinear()
+@test @inferred(IndexStyle(typeof(M))) == IndexLinear()
+@test @inferred(indices(M)) === indices(a)
 @test M == a + b
+@test @inferred(M[1]) === 11.0f0
 @test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
 
 c = view(reshape(1:9, 3, 3), 1:2, :)
 M = @inferred(mappedarray(+, c, b))
 @test @inferred(eltype(M)) == Float32
 @test @inferred(IndexStyle(M)) == IndexCartesian()
+@test @inferred(IndexStyle(typeof(M))) == IndexCartesian()
+@test @inferred(indices(M)) === indices(c)
 @test M == c + b
+@test @inferred(M[1]) === 11.0f0
 @test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0


### PR DESCRIPTION
This implements a lazy version of `map(f, A, B, C...)`.