### PR TITLE
setindex! for mappedarray(f, finv, A, B, C...) (and deprecate f_finv tuple) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ julia> a = [1,4,9,16]
  16
 
 julia> b = mappedarray(sqrt, a)
-4-element MappedArrays.ReadonlyMappedArray{Float64,1,Array{Int64,1},Base.#sqrt}:
+4-element mappedarray(sqrt, ::Array{Int64,1}) with eltype Float64:
  1.0
  2.0
  3.0
@@ -40,18 +40,19 @@ Note that you can't set values in the array:
 
 ```jl
 julia> b[3] = 2
-ERROR: indexed assignment not defined for MappedArrays.ReadonlyMappedArray{Float64,1,Array{Int64,1},Base.#sqrt}
- in setindex!(::MappedArrays.ReadonlyMappedArray{Float64,1,Array{Int64,1},Base.#sqrt}, ::Int64, ::Int64) at ./abstractarray.jl:781
- in eval(::Module, ::Any) at ./boot.jl:231
- in macro expansion at ./REPL.jl:92 [inlined]
- in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
+ERROR: setindex! not defined for ReadonlyMappedArray{Float64,1,Array{Int64,1},typeof(sqrt)}
+Stacktrace:
+ [1] error(::String, ::Type) at ./error.jl:42
+ [2] error_if_canonical_setindex at ./abstractarray.jl:1005 [inlined]
+ [3] setindex!(::ReadonlyMappedArray{Float64,1,Array{Int64,1},typeof(sqrt)}, ::Int64, ::Int64) at ./abstractarray.jl:996
+ [4] top-level scope at none:0
 ```
 
 **unless** you also supply the inverse function, using `mappedarray(f, finv, A)`:
 
 ```
 julia> c = mappedarray(sqrt, x->x*x, a)
-4-element MappedArrays.MappedArray{Float64,1,Array{Int64,1},Base.#sqrt,##1#2}:
+4-element mappedarray(sqrt, x->x * x, ::Array{Int64,1}) with eltype Float64:
  1.0
  2.0
  3.0
@@ -75,11 +76,13 @@ Naturally, the "backing" array `a` has to be able to represent any value that yo
 
 ```jl
 julia> c[3] = 2.2
-ERROR: InexactError()
- in setindex!(::MappedArrays.MappedArray{Float64,1,Array{Int64,1},Base.#sqrt,##1#2}, ::Float64, ::Int64) at /home/tim/.julia/v0.5/MappedArrays/src/MappedArrays.jl:27
- in eval(::Module, ::Any) at ./boot.jl:231
- in macro expansion at ./REPL.jl:92 [inlined]
- in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
+ERROR: InexactError: Int64(Int64, 4.840000000000001)
+Stacktrace:
+ [1] Type at ./float.jl:692 [inlined]
+ [2] convert at ./number.jl:7 [inlined]
+ [3] setindex! at ./array.jl:743 [inlined]
+ [4] setindex!(::MappedArray{Float64,1,Array{Int64,1},typeof(sqrt),getfield(Main, Symbol("##5#6"))}, ::Float64, ::Int64) at /home/tim/.julia/dev/MappedArrays/src/MappedArrays.jl:173
+ [5] top-level scope at none:0
 ```
 
 because `2.2^2 = 4.84` is not representable as an `Int`. In contrast,
@@ -93,7 +96,7 @@ julia> a = [1.0, 4.0, 9.0, 16.0]
  16.0
 
 julia> c = mappedarray(sqrt, x->x*x, a)
-4-element MappedArrays.MappedArray{Float64,1,Array{Float64,1},Base.#sqrt,##3#4}:
+4-element mappedarray(sqrt, x->x * x, ::Array{Float64,1}) with eltype Float64:
  1.0
  2.0
  3.0
@@ -106,7 +109,7 @@ julia> a
 4-element Array{Float64,1}:
   1.0
   4.0
-  4.84
+  4.840000000000001
  16.0
 ```
 
@@ -129,7 +132,7 @@ julia> a = randn(3,5,2)
  -0.315976  -0.188828  -0.567672   0.405086   1.06983
 
 julia> b = mappedarray(abs, a)
-3×5×2 MappedArrays.ReadonlyMappedArray{Float64,3,Array{Float64,3},Base.#abs}:
+3×5×2 mappedarray(abs, ::Array{Float64,3}) with eltype Float64:
 [:, :, 1] =
  1.47716   0.323915  0.448389  0.56426   2.67922
  0.255123  0.752548  0.41303   0.306604  1.5196
@@ -156,7 +159,7 @@ julia> b = [1 2; 3 4]
  3  4
 
 julia> c = mappedarray(+, a, b)
-2×2 MappedArrays.ReadonlyMultiMappedArray{Float64,2,Tuple{Array{Float64,2},Array{Int64,2}},typeof(+)}:
+2×2 mappedarray(+, ::Array{Float64,2}, ::Array{Int64,2}) with eltype Float64:
  1.1  2.2
  3.3  4.4
 ```
@@ -172,7 +175,7 @@ julia> greenchan = [0.8 0.75; 0.7 0.65];
 julia> bluechan = [0 1; 0 1];
 
 julia> m = mappedarray(RGB{Float64}, c->(red(c), green(c), blue(c)), redchan, greenchan, bluechan)
-2×2 MappedArrays.MultiMappedArray{RGB{Float64},2,Tuple{Array{Float64,2},Array{Float64,2},Array{Int64,2}},DataType,getfield(Main, Symbol("##5#6"))}:
+2×2 mappedarray(RGB{Float64}, getfield(Main, Symbol("##11#12"))(), ::Array{Float64,2}, ::Array{Float64,2}, ::Array{Int64,2}) with eltype RGB{Float64}:
  RGB{Float64}(0.1,0.8,0.0)  RGB{Float64}(0.2,0.75,1.0)
  RGB{Float64}(0.3,0.7,0.0)  RGB{Float64}(0.4,0.65,1.0)
 
@@ -185,6 +188,9 @@ julia> redchan
  0.3  0.4
 ```
 
+Note that in some cases the function or inverse-function is too
+complicated to print nicely in the summary line.
+
 ### of_eltype
 
 This package defines a convenience method, `of_eltype`, which
@@ -195,20 +201,10 @@ Using `of_eltype` you can "convert" a series of arrays to a chosen element type:
 
 ```julia
 julia> arrays = (rand(2,2), rand(Int,2,2), [0x01 0x03; 0x02 0x04])
-(
-[0.541018 0.223392; 0.341264 0.022014],
-
-[2437062103055434647 4726011606246170825; -4226911569217925847 -8715663020460318733],
-
-UInt8[0x01 0x03; 0x02 0x04])
+([0.984799 0.871579; 0.106783 0.0619827], [-6481735407318330164 5092084295348224098; -6063116549749853620 -8721118838052351006], UInt8[0x01 0x03; 0x02 0x04])
 
 julia> arraysT = map(A->of_eltype(Float64, A), arrays)
-(
-[0.541018 0.223392; 0.341264 0.022014],
-
-[2.43706e18 4.72601e18; -4.22691e18 -8.71566e18],
-
-[1.0 3.0; 2.0 4.0])
+([0.984799 0.871579; 0.106783 0.0619827], [-6.48174e18 5.09208e18; -6.06312e18 -8.72112e18], [1.0 3.0; 2.0 4.0])
 ```
 
 This construct is inferrable (type-stable), so it can be a useful

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ ERROR: indexed assignment not defined for MappedArrays.ReadonlyMappedArray{Float
  in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
 ```
 
-**unless** you also supply the inverse function, using `mappedarray((f, finv), A)`:
+**unless** you also supply the inverse function, using `mappedarray(f, finv, A)`:
 
 ```
-julia> c = mappedarray((sqrt, x->x*x), a)
+julia> c = mappedarray(sqrt, x->x*x, a)
 4-element MappedArrays.MappedArray{Float64,1,Array{Int64,1},Base.#sqrt,##1#2}:
  1.0
  2.0
@@ -92,7 +92,7 @@ julia> a = [1.0, 4.0, 9.0, 16.0]
   9.0
  16.0
 
-julia> c = mappedarray((sqrt, x->x*x), a)
+julia> c = mappedarray(sqrt, x->x*x, a)
 4-element MappedArrays.MappedArray{Float64,1,Array{Float64,1},Base.#sqrt,##3#4}:
  1.0
  2.0
@@ -161,7 +161,7 @@ julia> c = mappedarray(+, a, b)
  3.3  4.4
 ```
 
-In some cases you can also supply an inverse function:
+In some cases you can also supply an inverse function, which should return a tuple (one value for each input array):
 ```julia
 julia> using ColorTypes
 
@@ -171,7 +171,7 @@ julia> greenchan = [0.8 0.75; 0.7 0.65];
 
 julia> bluechan = [0 1; 0 1];
 
-julia> m = mappedarray((RGB{Float64}, c->(red(c), green(c), blue(c))), redchan, greenchan, bluechan)
+julia> m = mappedarray(RGB{Float64}, c->(red(c), green(c), blue(c)), redchan, greenchan, bluechan)
 2×2 MappedArrays.MultiMappedArray{RGB{Float64},2,Tuple{Array{Float64,2},Array{Float64,2},Array{Int64,2}},DataType,getfield(Main, Symbol("##5#6"))}:
  RGB{Float64}(0.1,0.8,0.0)  RGB{Float64}(0.2,0.75,1.0)
  RGB{Float64}(0.3,0.7,0.0)  RGB{Float64}(0.4,0.65,1.0)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ the package comes from the fact that `M == map(f, A)`.
 
 ## Usage
 
+### Single source arrays
+
 ```jl
 julia> using MappedArrays
 
@@ -137,6 +139,50 @@ julia> b = mappedarray(abs, a)
  0.799232  0.301813  0.457817  0.115742  1.22948
  0.486558  1.27959   1.59661   1.05867   2.06828
  0.315976  0.188828  0.567672  0.405086  1.06983
+```
+
+### Multiple source arrays
+
+Just as `map(f, a, b)` can take multiple containers `a` and `b`, `mappedarray` can too:
+```julia
+julia> a = [0.1 0.2; 0.3 0.4]
+2×2 Array{Float64,2}:
+ 0.1  0.2
+ 0.3  0.4
+
+julia> b = [1 2; 3 4]
+2×2 Array{Int64,2}:
+ 1  2
+ 3  4
+
+julia> c = mappedarray(+, a, b)
+2×2 MappedArrays.ReadonlyMultiMappedArray{Float64,2,Tuple{Array{Float64,2},Array{Int64,2}},typeof(+)}:
+ 1.1  2.2
+ 3.3  4.4
+```
+
+In some cases you can also supply an inverse function:
+```julia
+julia> using ColorTypes
+
+julia> redchan = [0.1 0.2; 0.3 0.4];
+
+julia> greenchan = [0.8 0.75; 0.7 0.65];
+
+julia> bluechan = [0 1; 0 1];
+
+julia> m = mappedarray((RGB{Float64}, c->(red(c), green(c), blue(c))), redchan, greenchan, bluechan)
+2×2 MappedArrays.MultiMappedArray{RGB{Float64},2,Tuple{Array{Float64,2},Array{Float64,2},Array{Int64,2}},DataType,getfield(Main, Symbol("##5#6"))}:
+ RGB{Float64}(0.1,0.8,0.0)  RGB{Float64}(0.2,0.75,1.0)
+ RGB{Float64}(0.3,0.7,0.0)  RGB{Float64}(0.4,0.65,1.0)
+
+ julia> m[1,2] = RGB(0,0,0)
+RGB{N0f8}(0.0,0.0,0.0)
+
+julia> redchan
+2×2 Array{Float64,2}:
+ 0.1  0.0
+ 0.3  0.4
 ```
 
 ### of_eltype

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -7,6 +7,7 @@ using Base: @propagate_inbounds
 export AbstractMappedArray, MappedArray, ReadonlyMappedArray, mappedarray, of_eltype
 
 abstract type AbstractMappedArray{T,N} <: AbstractArray{T,N} end
+abstract type AbstractMultiMappedArray{T,N} <: AbstractMappedArray{T,N} end
 
 struct ReadonlyMappedArray{T,N,A<:AbstractArray,F} <: AbstractMappedArray{T,N}
     f::F
@@ -17,7 +18,7 @@ struct MappedArray{T,N,A<:AbstractArray,F,Finv} <: AbstractMappedArray{T,N}
     finv::Finv
     data::A
 end
-struct ReadonlyMultiMappedArray{T,N,AAs<:Tuple{Vararg{AbstractArray}},F} <: AbstractMappedArray{T,N}
+struct ReadonlyMultiMappedArray{T,N,AAs<:Tuple{Vararg{AbstractArray}},F} <: AbstractMultiMappedArray{T,N}
     f::F
     data::AAs
 
@@ -27,8 +28,19 @@ struct ReadonlyMultiMappedArray{T,N,AAs<:Tuple{Vararg{AbstractArray}},F} <: Abst
         new(f, data)
     end
 end
+struct MultiMappedArray{T,N,AAs<:Tuple{Vararg{AbstractArray}},F,Finv} <: AbstractMultiMappedArray{T,N}
+    f::F
+    finv::Finv
+    data::AAs
 
-# TODO: remove @inline for 0.7
+    function MultiMappedArray{T,N,AAs,F,Finv}(f_finv::Tuple{F,Finv}, data) where {T,N,AAs,F,Finv}
+        inds = axes(first(data))
+        checkinds(inds, Base.tail(data)...)
+        f, finv = f_finv
+        new(f, finv, data)
+    end
+end
+
 @inline function checkinds(inds, A, As...)
     @noinline throw1(i, j) = throw(DimensionMismatch("arrays do not all have the same axes (got $i and $j)"))
     iA = axes(A)
@@ -48,25 +60,41 @@ not set them).
 
 When multiple input arrays are supplied, `M[i] = f(A[i], B[i], C[i]...)`.
 """
-mappedarray(f, data::AbstractArray{T,N}) where {T,N} = ReadonlyMappedArray{typeof(f(testvalue(data))),N,typeof(data),typeof(f)}(f, data)
+function mappedarray(f, data::AbstractArray)
+    T = typeof(f(testvalue(data)))
+    ReadonlyMappedArray{T,ndims(data),typeof(data),typeof(f)}(f, data)
+end
 
-mappedarray(f, data::AbstractArray...) = ReadonlyMultiMappedArray{typeof(f(map(testvalue, data)...)),ndims(first(data)),typeof(data),typeof(f)}(f, data)
+function mappedarray(f, data::AbstractArray...)
+    T = typeof(f(map(testvalue, data)...))
+    ReadonlyMultiMappedArray{T,ndims(first(data)),typeof(data),typeof(f)}(f, data)
+end
 
 """
-    mappedarray((f, finv), A)
+    M = mappedarray((f, finv), A)
+    M = mappedarray((f, finv), A, B, C...)
 
 creates a view of the array `A` that applies `f` to every element of
 `A`. The inverse function, `finv`, allows one to also set values of
 the view and, correspondingly, the values in `A`.
+
+When multiple input arrays are supplied, `M[i] = f(A[i], B[i], C[i]...)`.
 """
-function mappedarray(f_finv::Tuple{Any,Any}, data::AbstractArray{T,N}) where {T,N}
+function mappedarray(f_finv::Tuple{Any,Any}, data::AbstractArray)
     f, finv = f_finv
-    MappedArray{typeof(f(testvalue(data))),N,typeof(data),typeof(f),typeof(finv)}(f, finv, data)
+    T = typeof(f(testvalue(data)))
+    MappedArray{T,ndims(data),typeof(data),typeof(f),typeof(finv)}(f, finv, data)
+end
+
+function mappedarray(f_finv::Tuple{Any,Any}, data::AbstractArray...)
+    f, finv = f_finv
+    T = typeof(f(map(testvalue, data)...))
+    MultiMappedArray{T,ndims(first(data)),typeof(data),typeof(f),typeof(finv)}(f_finv, data)
 end
 
 """
-    of_eltype(T, A)
-    of_eltype(val::T, A)
+    M = of_eltype(T, A)
+    M = of_eltype(val::T, A)
 
 creates a view of `A` that lazily-converts the element type to `T`.
 """
@@ -76,70 +104,77 @@ of_eltype(::T, data::AbstractArray{S}) where {S,T} = of_eltype(T, data)
 
 Base.parent(A::AbstractMappedArray) = A.data
 Base.size(A::AbstractMappedArray) = size(A.data)
-Base.size(A::ReadonlyMultiMappedArray) = size(first(A.data))
+Base.size(A::AbstractMultiMappedArray) = size(first(A.data))
 Base.axes(A::AbstractMappedArray) = axes(A.data)
-Base.axes(A::ReadonlyMultiMappedArray) = axes(first(A.data))
+Base.axes(A::AbstractMultiMappedArray) = axes(first(A.data))
 parenttype(::Type{ReadonlyMappedArray{T,N,A,F}}) where {T,N,A,F} = A
 parenttype(::Type{MappedArray{T,N,A,F,Finv}}) where {T,N,A,F,Finv} = A
 parenttype(::Type{ReadonlyMultiMappedArray{T,N,A,F}}) where {T,N,A,F} = A
+parenttype(::Type{MultiMappedArray{T,N,A,F,Finv}}) where {T,N,A,F,Finv} = A
 Base.IndexStyle(::Type{MA}) where {MA<:AbstractMappedArray} = IndexStyle(parenttype(MA))
-@inline Base.IndexStyle(M::ReadonlyMultiMappedArray) = IndexStyle(M.data...)
-Base.IndexStyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} = _indexstyle(MA)
-Base.@pure _indexstyle(::Type{MA}) where {MA<:ReadonlyMultiMappedArray} =
+@inline Base.IndexStyle(M::AbstractMultiMappedArray) = IndexStyle(M.data...)
+Base.IndexStyle(::Type{MA}) where {MA<:AbstractMultiMappedArray} = _indexstyle(MA)
+Base.@pure _indexstyle(::Type{MA}) where {MA<:AbstractMultiMappedArray} =
     _indexstyle(map(IndexStyle, parenttype(MA).parameters)...)
 _indexstyle(a, b, c...) = _indexstyle(IndexStyle(a, b), c...)
 _indexstyle(a, b) = IndexStyle(a, b)
 
 
 # IndexLinear implementations
-@propagate_inbounds Base.getindex(A::AbstractMappedArray{T,1}, i::Int) where {T} =
+@inline @propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int) =
     A.f(A.data[i])
-@propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int) =
-    A.f(A.data[i])
-@propagate_inbounds Base.getindex(M::ReadonlyMultiMappedArray{T,1}, i::Int) where {T} =
+@inline @propagate_inbounds Base.getindex(M::AbstractMultiMappedArray, i::Int) =
     M.f(_getindex(i, M.data...)...)
-@propagate_inbounds Base.getindex(M::ReadonlyMultiMappedArray, i::Int) =
-    M.f(_getindex(i, M.data...)...)
-@propagate_inbounds function Base.setindex!(A::MappedArray{T,1},
-                                            val::T,
-                                            i::Int) where {T}
-    A.data[i] = A.finv(val)
+
+@inline @propagate_inbounds function Base.setindex!(A::MappedArray{T},
+                                                    val,
+                                                    i::Int) where {T}
+    A.data[i] = A.finv(convert(T, val)::T)
 end
-@propagate_inbounds function Base.setindex!(A::MappedArray{T},
-                                            val::T,
-                                            i::Int) where {T}
-    A.data[i] = A.finv(val)
+@inline @propagate_inbounds function Base.setindex!(A::MultiMappedArray{T},
+                                                    val,
+                                                    i::Int) where {T}
+    vals = A.finv(convert(T, val)::T)
+    _setindex!(A.data, vals, i)
+    return vals
 end
-@inline function Base.setindex!(A::MappedArray{T,1},
-                                val, i::Int) where {T}
-    setindex!(A, convert(T, val), i)
-end
-@inline function Base.setindex!(A::MappedArray{T},
-                                val, i::Int) where {T}
-    setindex!(A, convert(T, val), i)
-end
+
 
 # IndexCartesian implementations
-@propagate_inbounds function Base.getindex(A::AbstractMappedArray{T,N},
-                                           i::Vararg{Int,N}) where {T,N}
+@inline @propagate_inbounds function Base.getindex(A::AbstractMappedArray{T,N},
+                                                   i::Vararg{Int,N}) where {T,N}
     A.f(A.data[i...])
 end
-@propagate_inbounds function Base.getindex(M::ReadonlyMultiMappedArray{T,N},
-                                           i::Vararg{Int,N}) where {T,N}
+@inline @propagate_inbounds function Base.getindex(M::AbstractMultiMappedArray{T,N},
+                                                   i::Vararg{Int,N}) where {T,N}
     M.f(_getindex(CartesianIndex(i), M.data...)...)
 end
-@propagate_inbounds function Base.setindex!(A::MappedArray{T,N},
-                                            val::T,
-                                            i::Vararg{Int,N}) where {T,N}
-    A.data[i...] = A.finv(val)
+
+@inline @propagate_inbounds function Base.setindex!(A::MappedArray{T,N},
+                                                    val,
+                                                    i::Vararg{Int,N}) where {T,N}
+    A.data[i...] = A.finv(convert(T, val)::T)
 end
-@inline function Base.setindex!(A::MappedArray{T,N},
-                                val, i::Vararg{Int,N}) where {T,N}
-    setindex!(A, convert(T, val), i...)
+@inline @propagate_inbounds function Base.setindex!(A::MultiMappedArray{T,N},
+                                                    val,
+                                                    i::Vararg{Int,N}) where {T,N}
+    vals = A.finv(convert(T, val)::T)
+    _setindex!(A.data, vals, i...)
+    return vals
 end
 
-@propagate_inbounds _getindex(i, A, As...) = (A[i], _getindex(i, As...)...)
+
+@inline @propagate_inbounds _getindex(i, A, As...) = (A[i], _getindex(i, As...)...)
 _getindex(i) = ()
+
+@inline @propagate_inbounds function _setindex!(as::As, vals::Vs, inds::Vararg{Int,N}) where {As,Vs,N}
+    a1, atail = as[1], Base.tail(as)
+    v1, vtail = vals[1], Base.tail(vals)
+    a1[inds...] = v1
+    return _setindex!(atail, vtail, inds...)
+end
+_setindex!(as::Tuple{}, vals::Tuple{}, inds::Vararg{Int,N}) where N = nothing
+
 
 function testvalue(data)
     if !isempty(data)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 FixedPointNumbers 0.3.0
 OffsetArrays
+ColorTypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,3 +158,11 @@ end
     a = reshape(0.1:0.1:0.6, 3, 2)
     @test_throws DimensionMismatch mappedarray(f, finv, a, b, c)
 end
+
+@testset "Display" begin
+    a = [1,2,3,4]
+    b = mappedarray(sqrt, a)
+    @test summary(b) == "4-element mappedarray(sqrt, ::Array{Int64,1}) with eltype Float64"
+    c = mappedarray(sqrt, x->x*x, a)
+    @test summary(c) == "4-element mappedarray(sqrt, x->x * x, ::Array{Int64,1}) with eltype Float64"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,104 +3,158 @@ using Test
 
 @test isempty(detect_ambiguities(MappedArrays, Base, Core))
 
-using FixedPointNumbers, OffsetArrays
+using FixedPointNumbers, OffsetArrays, ColorTypes
 
-a = [1,4,9,16]
-s = view(a', 1:1, [1,2,4])
+@testset "ReadonlyMappedArray" begin
+    a = [1,4,9,16]
+    s = view(a', 1:1, [1,2,4])
 
-b = @inferred(mappedarray(sqrt, a))
-@test parent(b) === a
-@test eltype(b) == Float64
-@test @inferred(getindex(b, 1)) == 1
-@test b[2] == 2
-@test b[3] == 3
-@test b[4] == 4
-@test_throws ErrorException b[3] = 0
-@test isa(eachindex(b), AbstractUnitRange)
-b = mappedarray(sqrt, a')
-@test isa(eachindex(b), AbstractUnitRange)
-b = mappedarray(sqrt, s)
-@test isa(eachindex(b), CartesianIndices)
-
-c = @inferred(mappedarray((sqrt, x->x*x), a))
-@test parent(c) === a
-@test @inferred(getindex(c, 1)) == 1
-@test c[2] == 2
-@test c[3] == 3
-@test c[4] == 4
-c[3] = 2
-@test a[3] == 4
-@test_throws InexactError c[3] = 2.2  # because the backing array is Array{Int}
-@test isa(eachindex(c), AbstractUnitRange)
-b = @inferred(mappedarray(sqrt, a'))
-@test isa(eachindex(b), AbstractUnitRange)
-c = @inferred(mappedarray((sqrt, x->x*x), s))
-@test isa(eachindex(c), CartesianIndices)
-
-sb = similar(b)
-@test isa(sb, Array{Float64})
-@test size(sb) == size(b)
-
-a = [0x01 0x03; 0x02 0x04]
-b = @inferred(mappedarray((y->N0f8(y,0),x->x.i), a))
-for i = 1:4
-    @test b[i] == N0f8(i/255)
-end
-b[2,1] = 10/255
-@test a[2,1] == 0x0a
-
-a = [0.1 0.3; 0.2 0.4]
-b = @inferred(of_eltype(N0f8, a))
-@test b[1,1] === N0f8(0.1)
-b = @inferred(of_eltype(zero(N0f8), a))
-@test b[1,1] === N0f8(0.1)
-b[2,1] = N0f8(0.5)
-@test a[2,1] == N0f8(0.5)
-@test !(b === a)
-b = @inferred(of_eltype(Float64, a))
-@test b === a
-b = @inferred(of_eltype(0.0, a))
-@test b === a
-
-# OffsetArrays
-a = OffsetArray(randn(5), -2:2)
-aabs = mappedarray(abs, a)
-@test axes(aabs) == (-2:2,)
-for i = -2:2
-    @test aabs[i] == abs(a[i])
+    b = @inferred(mappedarray(sqrt, a))
+    @test parent(b) === a
+    @test eltype(b) == Float64
+    @test @inferred(getindex(b, 1)) == 1
+    @test b[2] == 2
+    @test b[3] == 3
+    @test b[4] == 4
+    @test_throws ErrorException b[3] = 0
+    @test isa(eachindex(b), AbstractUnitRange)
+    b = mappedarray(sqrt, a')
+    @test isa(eachindex(b), AbstractUnitRange)
+    b = mappedarray(sqrt, s)
+    @test isa(eachindex(b), CartesianIndices)
 end
 
-# issue #7
-astr = @inferred(mappedarray(length, ["abc", "onetwothree"]))
-@test eltype(astr) == Int
-@test astr == [3, 11]
-a = @inferred(mappedarray(x->x+0.5, Int[]))
-@test eltype(a) == Float64
+@testset "MappedArray" begin
+    intsym = Int == Int64 ? :Int64 : :Int32
+    a = [1,4,9,16]
+    s = view(a', 1:1, [1,2,4])
+    c = @inferred(mappedarray((sqrt, x->x*x), a))
+    @test parent(c) === a
+    @test @inferred(getindex(c, 1)) == 1
+    @test c[2] == 2
+    @test c[3] == 3
+    @test c[4] == 4
+    c[3] = 2
+    @test a[3] == 4
+    @test_throws InexactError(intsym, Int, 2.2^2) c[3] = 2.2  # because the backing array is Array{Int}
+    @test isa(eachindex(c), AbstractUnitRange)
+    b = @inferred(mappedarray(sqrt, a'))
+    @test isa(eachindex(b), AbstractUnitRange)
+    c = @inferred(mappedarray((sqrt, x->x*x), s))
+    @test isa(eachindex(c), CartesianIndices)
 
-# typestable string
-astr = @inferred(mappedarray(uppercase, ["abc", "def"]))
-@test eltype(astr) == String
-@test astr == ["ABC","DEF"]
+    sb = similar(b)
+    @test isa(sb, Array{Float64})
+    @test size(sb) == size(b)
 
-# multiple arrays
-a = reshape(1:6, 2, 3)
-@test @inferred(axes(a)) == (Base.OneTo(2), Base.OneTo(3)) # prevents error on 0.7
-b = fill(10.0f0, 2, 3)
-M = @inferred(mappedarray(+, a, b))
-@test @inferred(eltype(M)) == Float32
-@test @inferred(IndexStyle(M)) == IndexLinear()
-@test @inferred(IndexStyle(typeof(M))) == IndexLinear()
-@test @inferred(axes(M)) === axes(a)
-@test M == a + b
-@test @inferred(M[1]) === 11.0f0
-@test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
+    a = [0x01 0x03; 0x02 0x04]
+    b = @inferred(mappedarray((y->N0f8(y,0),x->x.i), a))
+    for i = 1:4
+        @test b[i] == N0f8(i/255)
+    end
+    b[2,1] = 10/255
+    @test a[2,1] == 0x0a
+end
 
-c = view(reshape(1:9, 3, 3), 1:2, :)
-M = @inferred(mappedarray(+, c, b))
-@test @inferred(eltype(M)) == Float32
-@test @inferred(IndexStyle(M)) == IndexCartesian()
-@test @inferred(IndexStyle(typeof(M))) == IndexCartesian()
-@test @inferred(axes(M)) === axes(c)
-@test M == c + b
-@test @inferred(M[1]) === 11.0f0
-@test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
+@testset "of_eltype" begin
+    a = [0.1 0.3; 0.2 0.4]
+    b = @inferred(of_eltype(N0f8, a))
+    @test b[1,1] === N0f8(0.1)
+    b = @inferred(of_eltype(zero(N0f8), a))
+    @test b[1,1] === N0f8(0.1)
+    b[2,1] = N0f8(0.5)
+    @test a[2,1] == N0f8(0.5)
+    @test !(b === a)
+    b = @inferred(of_eltype(Float64, a))
+    @test b === a
+    b = @inferred(of_eltype(0.0, a))
+    @test b === a
+end
+
+@testset "OffsetArrays" begin
+    a = OffsetArray(randn(5), -2:2)
+    aabs = mappedarray(abs, a)
+    @test axes(aabs) == (-2:2,)
+    for i = -2:2
+        @test aabs[i] == abs(a[i])
+    end
+end
+
+@testset "No zero(::T)" begin
+    astr = @inferred(mappedarray(length, ["abc", "onetwothree"]))
+    @test eltype(astr) == Int
+    @test astr == [3, 11]
+    a = @inferred(mappedarray(x->x+0.5, Int[]))
+    @test eltype(a) == Float64
+
+    # typestable string
+    astr = @inferred(mappedarray(uppercase, ["abc", "def"]))
+    @test eltype(astr) == String
+    @test astr == ["ABC","DEF"]
+end
+
+@testset "ReadOnlyMultiMappedArray" begin
+    a = reshape(1:6, 2, 3)
+#    @test @inferred(axes(a)) == (Base.OneTo(2), Base.OneTo(3))
+    b = fill(10.0f0, 2, 3)
+    M = @inferred(mappedarray(+, a, b))
+    @test @inferred(eltype(M)) == Float32
+    @test @inferred(IndexStyle(M)) == IndexLinear()
+    @test @inferred(IndexStyle(typeof(M))) == IndexLinear()
+    @test @inferred(size(M)) === size(a)
+    @test @inferred(axes(M)) === axes(a)
+    @test M == a + b
+    @test @inferred(M[1]) === 11.0f0
+    @test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
+
+    c = view(reshape(1:9, 3, 3), 1:2, :)
+    M = @inferred(mappedarray(+, c, b))
+    @test @inferred(eltype(M)) == Float32
+    @test @inferred(IndexStyle(M)) == IndexCartesian()
+    @test @inferred(IndexStyle(typeof(M))) == IndexCartesian()
+    @test @inferred(axes(M)) === axes(c)
+    @test M == c + b
+    @test @inferred(M[1]) === 11.0f0
+    @test @inferred(M[CartesianIndex(1, 1)]) === 11.0f0
+end
+
+@testset "MultiMappedArray" begin
+    intsym = Int == Int64 ? :Int64 : :Int32
+    a = [0.1 0.2; 0.3 0.4]
+    b = N0f8[0.6 0.5; 0.4 0.3]
+    c = [0 1; 0 1]
+    f_finv = ( (r,g,b)->RGB{N0f8}(r,g,b),
+               c->(red(c), green(c), blue(c)))
+    M = @inferred(mappedarray(f_finv, a, b, c))
+    @test @inferred(eltype(M)) == RGB{N0f8}
+    @test @inferred(IndexStyle(M)) == IndexLinear()
+    @test @inferred(IndexStyle(typeof(M))) == IndexLinear()
+    @test @inferred(size(M)) === size(a)
+    @test @inferred(axes(M)) === axes(a)
+    @test M[1,1] === RGB{N0f8}(0.1, 0.6, 0)
+    @test M[2,1] === RGB{N0f8}(0.3, 0.4, 0)
+    @test M[1,2] === RGB{N0f8}(0.2, 0.5, 1)
+    @test M[2,2] === RGB{N0f8}(0.4, 0.3, 1)
+    M[1,2] = RGB(0.25, 0.35, 0)
+    @test M[1,2] === RGB{N0f8}(0.25, 0.35, 0)
+    @test a[1,2] == N0f8(0.25)
+    @test b[1,2] == N0f8(0.35)
+    @test c[1,2] == 0
+    @test_throws InexactError(intsym, Int, N0f8(0.45)) M[1,2] = RGB(0.25, 0.35, 0.45)
+    R = reinterpret(N0f8, M)
+    @test R == N0f8[0.1 0.25; 0.6 0.35; 0 0; 0.3 0.4; 0.4 0.3; 0 1]
+    R[2,1] = 0.8
+    @test b[1,1] === N0f8(0.8)
+
+    a = view(reshape(0.1:0.1:0.6, 3, 2), 1:2, 1:2)
+    M = @inferred(mappedarray(f_finv, a, b, c))
+    @test @inferred(eltype(M)) == RGB{N0f8}
+    @test @inferred(IndexStyle(M)) == IndexCartesian()
+    @test @inferred(IndexStyle(typeof(M))) == IndexCartesian()
+    @test @inferred(axes(M)) === axes(a)
+    @test M[1,1] === RGB{N0f8}(0.1, 0.8, 0)
+    @test_throws ErrorException("indexed assignment fails for a reshaped range; consider calling collect") M[1,2] = RGB(0.25, 0.35, 0)
+
+    a = reshape(0.1:0.1:0.6, 3, 2)
+    @test_throws DimensionMismatch mappedarray(f_finv, a, b, c)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ end
     intsym = Int == Int64 ? :Int64 : :Int32
     a = [1,4,9,16]
     s = view(a', 1:1, [1,2,4])
-    c = @inferred(mappedarray((sqrt, x->x*x), a))
+    c = @inferred(mappedarray(sqrt, x->x*x, a))
     @test parent(c) === a
     @test @inferred(getindex(c, 1)) == 1
     @test c[2] == 2
@@ -40,7 +40,7 @@ end
     @test isa(eachindex(c), AbstractUnitRange)
     b = @inferred(mappedarray(sqrt, a'))
     @test isa(eachindex(b), AbstractUnitRange)
-    c = @inferred(mappedarray((sqrt, x->x*x), s))
+    c = @inferred(mappedarray(sqrt, x->x*x, s))
     @test isa(eachindex(c), CartesianIndices)
 
     sb = similar(b)
@@ -48,7 +48,7 @@ end
     @test size(sb) == size(b)
 
     a = [0x01 0x03; 0x02 0x04]
-    b = @inferred(mappedarray((y->N0f8(y,0),x->x.i), a))
+    b = @inferred(mappedarray(y->N0f8(y,0), x->x.i, a))
     for i = 1:4
         @test b[i] == N0f8(i/255)
     end
@@ -123,9 +123,9 @@ end
     a = [0.1 0.2; 0.3 0.4]
     b = N0f8[0.6 0.5; 0.4 0.3]
     c = [0 1; 0 1]
-    f_finv = ( (r,g,b)->RGB{N0f8}(r,g,b),
-               c->(red(c), green(c), blue(c)))
-    M = @inferred(mappedarray(f_finv, a, b, c))
+    f = RGB{N0f8}
+    finv = c->(red(c), green(c), blue(c))
+    M = @inferred(mappedarray(f, finv, a, b, c))
     @test @inferred(eltype(M)) == RGB{N0f8}
     @test @inferred(IndexStyle(M)) == IndexLinear()
     @test @inferred(IndexStyle(typeof(M))) == IndexLinear()
@@ -147,7 +147,7 @@ end
     @test b[1,1] === N0f8(0.8)
 
     a = view(reshape(0.1:0.1:0.6, 3, 2), 1:2, 1:2)
-    M = @inferred(mappedarray(f_finv, a, b, c))
+    M = @inferred(mappedarray(f, finv, a, b, c))
     @test @inferred(eltype(M)) == RGB{N0f8}
     @test @inferred(IndexStyle(M)) == IndexCartesian()
     @test @inferred(IndexStyle(typeof(M))) == IndexCartesian()
@@ -156,5 +156,5 @@ end
     @test_throws ErrorException("indexed assignment fails for a reshaped range; consider calling collect") M[1,2] = RGB(0.25, 0.35, 0)
 
     a = reshape(0.1:0.1:0.6, 3, 2)
-    @test_throws DimensionMismatch mappedarray(f_finv, a, b, c)
+    @test_throws DimensionMismatch mappedarray(f, finv, a, b, c)
 end


### PR DESCRIPTION
This rounds out the functionality for multi-mapping supporting `m[i] = v` for `m = mappedarray(f, finv, A, B, C...)`.

This also switches the writable interface from `mappedarray((f, finv), A, ...)` to `mappedarray(f, finv, A, ...)`. This seems necessary in order to ensure inferrability if `f` or `finv` is a type. The only downside I see is that since any object can be made callable, this really commits at the API level to insisting that `A::AbstractArray` in order to be able to reliably resolve intent.