### PR TITLE
remove precompile statement

### DIFF
--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module MappedArrays
 
 using Base: @propagate_inbounds


### PR DESCRIPTION
To get rid of the warning (precompile is now default)