### PR TITLE
RFC: Remove type restriction on indices

### DIFF
--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -136,19 +136,19 @@ _indexstyle(a, b) = IndexStyle(a, b)
 
 
 # IndexLinear implementations
-@inline @propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Int) =
+@inline @propagate_inbounds Base.getindex(A::AbstractMappedArray, i::Any) =
     A.f(A.data[i])
-@inline @propagate_inbounds Base.getindex(M::AbstractMultiMappedArray, i::Int) =
+@inline @propagate_inbounds Base.getindex(M::AbstractMultiMappedArray, i::Any) =
     M.f(_getindex(i, M.data...)...)
 
 @inline @propagate_inbounds function Base.setindex!(A::MappedArray{T},
                                                     val,
-                                                    i::Int) where {T}
+                                                    i::Any) where {T}
     A.data[i] = A.finv(convert(T, val)::T)
 end
 @inline @propagate_inbounds function Base.setindex!(A::MultiMappedArray{T},
                                                     val,
-                                                    i::Int) where {T}
+                                                    i::Any) where {T}
     vals = A.finv(convert(T, val)::T)
     _setindex!(A.data, vals, i)
     return vals
@@ -157,22 +157,22 @@ end
 
 # IndexCartesian implementations
 @inline @propagate_inbounds function Base.getindex(A::AbstractMappedArray{T,N},
-                                                   i::Vararg{Int,N}) where {T,N}
+                                                   i::Vararg{Any,N}) where {T,N}
     A.f(A.data[i...])
 end
 @inline @propagate_inbounds function Base.getindex(A::AbstractMultiMappedArray{T,N},
-                                                   i::Vararg{Int,N}) where {T,N}
+                                                   i::Vararg{Any,N}) where {T,N}
     A.f(_getindex(CartesianIndex(i), A.data...)...)
 end
 
 @inline @propagate_inbounds function Base.setindex!(A::MappedArray{T,N},
                                                     val,
-                                                    i::Vararg{Int,N}) where {T,N}
+                                                    i::Vararg{Any,N}) where {T,N}
     A.data[i...] = A.finv(convert(T, val)::T)
 end
 @inline @propagate_inbounds function Base.setindex!(A::MultiMappedArray{T,N},
                                                     val,
-                                                    i::Vararg{Int,N}) where {T,N}
+                                                    i::Vararg{Any,N}) where {T,N}
     vals = A.finv(convert(T, val)::T)
     _setindex!(A.data, vals, i...)
     return vals


### PR DESCRIPTION
In https://github.com/eschnett/SIMD.jl/pull/40, I sent a PR to SIMD.jl so that writing SIMD-based code can use a more Julian syntax `a[vi]`.  Here, `vi` is a special object for retrieving a SIMD vector from an array.  Unfortunately, it cannot be used with MappedArrays.jl since it requires indices to be `Int`s.  I wonder if it is possible/makes sense to loosen such restriction so that MappedArrays.jl and SIMD.jl play well together; hence this PR/RFC.

Here is a toy example to demonstrate the usage.  It computes a dot product using SIMD.jl:

```julia
using SIMD
using MappedArrays

@inline function vdot(xs, ys, ::Type{Vec{N,T}} = Vec{4,Float64}) where {N,T}
    @assert length(ys) == length(xs)
    @assert length(xs) % N == 0
    lane = VecRange{N}(0)
    vacc = zero(Vec{N, T})
    @inbounds for i in 1:N:length(xs)
        vacc = muladd(xs[lane + i], ys[lane + i], vacc)
    end
    return sum(vacc)
end
```

Note that `lane + i` is the special object `vi` I mentioned above.

With this PR, mappedarrays can be passed to `vdot` directly:

```julia
arr1 = randn(2^20)
arr2 = randn(2^20)
f1(x) = x*x + x
f2(x) = x*x*x + 1
ma1 = mappedarray(f1, arr1)
ma2 = mappedarray(f2, arr2)

@assert vdot(ma1, ma2) ≈ vdot(f1.(arr1), f2.(arr2))

using BenchmarkTools
(bc = @benchmark vdot($ma1, $ma2)) |> display  # MappedArrays.jl + SIMD.jl
ba = @benchmark begin
    a1 = $(similar(arr1))
    a2 = $(similar(arr2))
    copyto!(a1, $ma1)
    copyto!(a2, $ma2)
    vdot(a1, a2)
end
display(ba)
judge(minimum.((bc, ba))...)
```

This benchmark shows that "fusing" the mapping and reducing (`vdot`) is a big win:

```julia
BenchmarkTools.TrialJudgement:
  time:   -76.37% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)
```

SIMD version is faster also than normal `dot`:

```julia
julia> bs = @benchmark dot($ma1, $ma2)
       judge(minimum.((bc, bs))...)
BenchmarkTools.TrialJudgement:
  time:   -47.11% => improvement (5.00% tolerance)
  memory: +0.00% => invariant (1.00% tolerance)
```

Of course, an obvious disadvantage of this PR is that duck-typing complicates the stacktrace and so debugging.  However, I think automatic 2x to 4x speedup is good enough for sacrificing a bit of debuggability.
