### PR TITLE
drop typeassert

### DIFF
--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -196,7 +196,7 @@ function testvalue(data)
         first(data)
     else
         zero(eltype(data))
-    end::eltype(data)
+    end
 end
 
 ## Display


### PR DESCRIPTION
Hi,

This package is really useful for me, thank you :)

There is one problem that's giving me some trouble. `testvalue` is defined as
```julia
function testvalue(data)
    if !isempty(data)
        first(data)
    else
        zero(eltype(data))
    end::eltype(data)
end
```

That `::eltype(data)` makes this package less flexible than it could be, and keeps it from working for my use case.

I'm starting with something like
```julia
using ElasticArrays
using ArraysOfArrays

function arrayvec(T::Type, n, dims::NTuple{k, Int}) where {k}
    nestedview(ElasticArray{T,k+1}(undef, dims..., n), k)
end

arrvec = arrayvec(Float64, 3, (2,))
arrvec.data .= randn(2,3)
```

which produces e.g.
```julia
julia> arrvec
3-element ArrayOfSimilarArrays{Float64, 1, 1, 2, ElasticMatrix{Float64, 1, Vector{Float64}}}:
 [-1.337556552638059, -0.21815125376839456]
 [-1.396845281252145, 0.8373323575162874]
 [-1.3983969604896964, -0.11563361403037231]
```

I really like this because it's an efficient representation, and it's efficient to add new rows.

Now I'd like this, which works in my tiny PR:
```julia
julia> marr = mappedarray(t, arrvec)
3-element mappedarray(TransformVariables.TransformTuple{NamedTuple{(:x, :y), Tuple{TransformVariables.ScaledShiftedLogistic{Float64}, TransformVariables.ShiftedExp{true, Float64}}}}((x = as𝕀, y = asℝ₊), 2), ::ArrayOfSimilarArrays{Float64, 1, 1, 2, ElasticMatrix{Float64, 1, Vector{Float64}}}) with eltype NamedTuple{(:x, :y), Tuple{Float64, Float64}}:
 (x = 0.20791216976667765, y = 0.8040038238610532)
 (x = 0.19831719493246036, y = 2.3101959725021204)
 (x = 0.1980706128310006, y = 0.8908015407009987)
```

The long type name is not great, but that's easily fixed with a little wrapper.

The change I'm proposing is (I think) very minor, and will make this package easily useful for cases like this.