### PR TITLE
[WIP] ProductedArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "MappedArrays"
 uuid = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 version = "0.3.0"
 
+[deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
 [compat]
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 julia = "1"

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -4,6 +4,10 @@ using Base: @propagate_inbounds
 
 export AbstractMappedArray, MappedArray, ReadonlyMappedArray, mappedarray, of_eltype
 
+using Reexport
+include("ProductedArrays.jl")
+@reexport using .ProductedArrays
+
 abstract type AbstractMappedArray{T,N} <: AbstractArray{T,N} end
 abstract type AbstractMultiMappedArray{T,N} <: AbstractMappedArray{T,N} end
 

--- a/src/ProductedArrays.jl
+++ b/src/ProductedArrays.jl
@@ -1,0 +1,24 @@
+module ProductedArrays
+    export ProductedArray
+
+    struct ProductedArray{T, N, AAs<:Tuple{Vararg{AbstractArray}}} <: AbstractArray{T, N}
+        data::AAs
+    end
+    function ProductedArray(data...)
+        ProductedArray{typeof(map(first, data)), mapreduce(ndims, +, data), typeof(data)}(data)
+    end
+
+    @inline Base.size(A::ProductedArray) = mapreduce(size, (i,j)->(i...,j...), A.data)
+
+    Base.@propagate_inbounds function Base.getindex(A::ProductedArray{T, N}, inds::Vararg{Int, N}) where {T, N}
+        map((x, i)->x[i...], A.data, _split_indices(A, inds))
+    end
+
+    # TODO: this fails to inline and thus gives about 1.5ns overhead to getindex
+    @inline function _split_indices(A::ProductedArray{T, N}, inds::NTuple{N, Int}) where {T, N}
+        # TODO: this line is repeatedly computed
+        pos = (firstindex(A.data)-1, accumulate(+, map(ndims, A.data))...)
+
+        return ntuple(i->inds[pos[i]+1:pos[i+1]], length(pos)-1)
+    end
+end


### PR DESCRIPTION
This introduces an intermediate Cartesian product array type that can be used for many operations, depending on how we're going to reduce the item. I'll give two examples that motivate this PR.

TODO:

- [ ] performance tweak
- [ ] tests and docs

## Example: ReadonlyMultiMappedArray

```julia
a = Float64[0.1 0.2; 0.3 0.4]
b = [1 2; 3 4]

plusc_1 = mappedarray(+, a, b)

p = ProductedArray(a, b)
plusc_2 = mappedarray(i->reduce(+, p[i, i]), CartesianIndices(a))

plusc_1 == plusc_2 # true
```

Theoretically, we could build the *MultiMappedArray functionality on top of `ProductedArray` and thus simplify the implementation. To minimize the change, I might take a try but won't do it in this PR.

## Example: patch wise distances

```julia
using Distances
A = [rand(Float64, 7, 7) for _ in 1:7];
B = [rand(Float64, 7, 7) for _ in 1:7];

patchwise_d1 = [euclidean(a, b) for a in A, b in B]

p = ProductedArray(A, B);
patchwise_d2 = mappedarray(x->reduce(euclidean, x), p)

patchwise_d1 == patchwise_d2 # true
```