### PR TITLE
fix inference failure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,10 @@ FixedPointNumbers = "0.6.1, 0.7, 0.8"
 julia = "1"
 
 [extras]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OffsetArrays", "ColorTypes", "Test", "FixedPointNumbers"]
+test = ["OffsetArrays", "Colors", "Test", "FixedPointNumbers"]

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -58,7 +58,8 @@ not set them).
 When multiple input arrays are supplied, `M[i] = f(A[i], B[i], C[i]...)`.
 """
 function mappedarray(f, data::AbstractArray)
-    T = Base._return_type(f, eltypes(data))
+    infer_eltype() = Base._return_type(f, eltypes(data))
+    T = infer_eltype()
     ReadonlyMappedArray{T,ndims(data),typeof(data),typeof(f)}(f, data)
 end
 
@@ -67,7 +68,8 @@ function mappedarray(::Type{T}, data::AbstractArray) where T
 end
 
 function mappedarray(f, data::AbstractArray...)
-    T = Base._return_type(f, eltypes(data))
+    infer_eltype() = Base._return_type(f, eltypes(data))
+    T = infer_eltype()
     ReadonlyMultiMappedArray{T,ndims(first(data)),typeof(data),typeof(f)}(f, data)
 end
 
@@ -86,12 +88,14 @@ the view and, correspondingly, the values in `A`.
 When multiple input arrays are supplied, `M[i] = f(A[i], B[i], C[i]...)`.
 """
 function mappedarray(f, finv, data::AbstractArray)
-    T = Base._return_type(f, eltypes(data))
+    infer_eltype() = Base._return_type(f, eltypes(data))
+    T = infer_eltype()
     MappedArray{T,ndims(data),typeof(data),typeof(f),typeof(finv)}(f, finv, data)
 end
 
 function mappedarray(f, finv, data::AbstractArray...)
-    T = Base._return_type(f, eltypes(data))
+    infer_eltype() = Base._return_type(f, eltypes(data))
+    T = infer_eltype()
     MultiMappedArray{T,ndims(first(data)),typeof(data),typeof(f),typeof(finv)}(f, finv, data)
 end
 
@@ -99,7 +103,8 @@ function mappedarray(::Type{T}, finv, data::AbstractArray...) where T
     MultiMappedArray{T,ndims(first(data)),typeof(data),Type{T},typeof(finv)}(T, finv, data)
 end
 function mappedarray(f, ::Type{Finv}, data::AbstractArray...) where Finv
-    T = Base._return_type(f, eltypes(data))
+    infer_eltype() = Base._return_type(f, eltypes(data))
+    T = infer_eltype()
     MultiMappedArray{T,ndims(first(data)),typeof(data),typeof(f),Type{Finv}}(f, Finv, data)
 end
 
@@ -113,7 +118,7 @@ end
 
 creates a view of `A` that lazily-converts the element type to `T`.
 """
-of_eltype(::Type{T}, data::AbstractArray{S}) where {S,T} = mappedarray(x->convert(T,x), y->convert(S,y), data)
+of_eltype(::Type{T}, data::AbstractArray{S}) where {S,T} = mappedarray(x->convert(T,x)::T, y->convert(S,y)::S, data)
 of_eltype(::Type{T}, data::AbstractArray{T}) where {T} = data
 of_eltype(::T, data::AbstractArray{S}) where {S,T} = of_eltype(T, data)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 
 @test isempty(detect_ambiguities(MappedArrays, Base, Core))
 
-using FixedPointNumbers, OffsetArrays, ColorTypes
+using FixedPointNumbers, OffsetArrays, Colors
 
 @testset "ReadonlyMappedArray" begin
     a = [1,4,9,16]
@@ -213,4 +213,9 @@ end
     @test eltype(mappedarray(_maybe_int, Float64, [1, -1])) == Int64
     @test eltype(mappedarray(Float64, _maybe_int, [1.0, 1, -1, -1.0])) == Float64
     @test eltype(mappedarray(Float64, _maybe_int, [1, -1])) == Float64
+
+    X = rand(Lab{Float32}, 4, 4)
+    @test eltype(of_eltype(RGB{Float32}, X)) == RGB{Float32}
+    X = Any[1, 2, 3]
+    @test eltype(of_eltype(Int, X)) == Int
 end


### PR DESCRIPTION
This also fixes the CI error in https://github.com/JuliaImages/ImageQualityIndexes.jl/pull/36 where `channelview` doesn't work on `of_eltype(RGB{Float32, rand(Lab{Float32}, 4, 4))` because `channelview` assumes eltype to be concrete colorant, not `Any`.

I first notice this in https://github.com/JuliaMath/Interpolations.jl/pull/446#discussion_r673712940 but still, I'm really not sure what's behind the scene:

```julia
    infer_eltype() = Base._return_type(f, eltypes(data))
    T = infer_eltype()
```

closes #47