### PR TITLE
Update runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
     @test eltype(mappedarray(identity, [missing, 1])) == Union{Missing, Int}
 
     # ReadonlyMappedArray and MappedArray
-    _zero(x) = x > 0 ? x : 0
+    _zero(x) = ismissing(x) ? x : (x > 0 ? x : 0)
     @test eltype(mappedarray(_zero, [1, 1.0])) == Union{Float64,Int}
     @test eltype(mappedarray(_zero, [1.0, 1])) == Union{Float64,Int}
     @test eltype(mappedarray(_zero, [1, 1])) == Int


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/43852 will improve inference making it
realize that `_zero(::Missing)` throws such that `_sum` can never return `missing`,
breaking the inference test below because the return type is more precise than expected.