### PR TITLE
Fix deprecation warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
+          - "1.0"  # oldest supported version
+          - "1.6"  # LTS
           - "1"    # Latest release
           - nightly
         os:

--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -261,7 +261,7 @@ function func_print(io, f, types)
 end
 
 eltypes(A::AbstractArray) = Tuple{eltype(A)}
-@Base.pure eltypes(A::Tuple{Vararg{<:AbstractArray}}) = Tuple{(eltype.(A))...}
+@Base.pure eltypes(A::Tuple{Vararg{AbstractArray}}) = Tuple{(eltype.(A))...}
 
 ## Deprecations
 @deprecate mappedarray(f_finv::Tuple{Any,Any}, args::AbstractArray...) mappedarray(f_finv[1], f_finv[2], args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,11 @@ using FixedPointNumbers, OffsetArrays, Colors
     @test b[2] == 2
     @test b[3] == 3
     @test b[4] == 4
-    @test_throws ErrorException b[3] = 0
+    if isdefined(Base, :CanonicalIndexError)
+        @test_throws CanonicalIndexError b[3] = 0
+    else
+        @test_throws ErrorException b[3] = 0
+    end
     @test isa(eachindex(b), AbstractUnitRange)
     b = mappedarray(sqrt, a')
     @test isa(eachindex(b), AbstractUnitRange)
@@ -201,7 +205,7 @@ end
 
     # MultiMappedArray and ReadonlyMultiMappedArray
     _sum(x, y) = _zero(x) + _zero(y)
-    inferred_type = VERSION >= v"1.6.0-RC1" ? Union{Missing, Float64, Int64} : Any
+    inferred_type = Union{Missing, Float64, Int64}
     @test eltype(mappedarray(_sum, [1, 1.0], [1.0, missing])) == inferred_type
     @test eltype(mappedarray(_sum, [1, 1], [2, 2])) == Int
     @test eltype(mappedarray(_sum, identity, [1, 1.0], [1.0, missing])) == inferred_type


### PR DESCRIPTION
On Julia 1.7.2 with `--depwarn=error` this expression `Vararg{<:AbstractArray}` causes the error
```julia
ERROR: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
Stacktrace:
 [1] UnionAll(v::TypeVar, t::Any)
   @ Core ./boot.jl:255
 [2] top-level scope
   @ REPL[25]:1
```