### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/MappedArrays.jl
+++ b/src/MappedArrays.jl
@@ -261,7 +261,7 @@ function func_print(io, f, types)
 end
 
 eltypes(A::AbstractArray) = Tuple{eltype(A)}
-@Base.pure eltypes(A::Tuple{Vararg{<:AbstractArray}}) = Tuple{(eltype.(A))...}
+@Base.pure eltypes(A::Tuple{Vararg{AbstractArray}}) = Tuple{(eltype.(A))...}
 
 ## Deprecations
 @deprecate mappedarray(f_finv::Tuple{Any,Any}, args::AbstractArray...) mappedarray(f_finv[1], f_finv[2], args...)


### PR DESCRIPTION
Adjusted the code that was generating these deprecation warnings:
![Captura de tela de 2023-05-14 16-23-02](https://github.com/JuliaArrays/MappedArrays.jl/assets/73039601/af85842d-a45a-45c3-8ca6-d080feb7af8d)
